### PR TITLE
Update day-of-week.blade.php

### DIFF
--- a/resources/views/day-of-week.blade.php
+++ b/resources/views/day-of-week.blade.php
@@ -2,7 +2,7 @@
      style="min-width: 10rem;">
 
     <p class="text-sm">
-        {{ $day->format('l') }}
+        {{ $day->isoFormat('dddd') }}
     </p>
 
 </div>


### PR DESCRIPTION
`isoFormat` respects the Carbon locale. `format` does not.

when locale is set to da.
`format` would still output monday, tuesday, wednesday etc. `isoFormat` will output mandag, tirsdag, onsdag, etc.